### PR TITLE
Update to latest version and move tagspace source to right directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:trusty
-ENV TAGSPACES_VERSION 2.7.5
+ENV TAGSPACES_VERSION 2.9.0
 RUN apt-get update && apt-get install -y nginx nginx-extras apache2-utils && apt-get install -y wget unzip
 
 VOLUME /var/dav
@@ -11,6 +11,7 @@ COPY entrypoint.sh /
 RUN chmod +x entrypoint.sh \
  && wget https://github.com/tagspaces/tagspaces/releases/download/v${TAGSPACES_VERSION}/tagspaces-${TAGSPACES_VERSION}-web.zip \
  && unzip tagspaces-${TAGSPACES_VERSION}-web.zip \
- && mv tagspaces /usr/share/nginx/www \
+ && mkdir /usr/share/nginx/www \
+ && mv tagspaces /usr/share/nginx/www/tagspaces \
  && rm -rf tagspaces-${TAGSPACES_VERSION}-web.zip
 CMD nginx -g "daemon off;"


### PR DESCRIPTION
The tagspaces source was moved to the wrong directory in the nginx directory